### PR TITLE
docs: expand development guide with AWS setup and Bun usage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,11 +25,13 @@ Order management and back-office system for a print/mold shop. Turborepo monorep
 
 ```bash
 bun install           # Install dependencies
-bun dev               # Start dev server
-bun build             # Build all packages
-bun lint              # Lint all packages
-bun format            # Format with Prettier
+bun run dev           # Start dev server
+bun run build         # Build all packages
+bun run lint          # Lint all packages
+bun run format        # Format with Prettier
 ```
+
+Use `bun run <script>` for package scripts. `bun build` (without `run`) invokes Bun's built-in bundler, not the Turborepo `build` task. `bun install` is the exception — it's a built-in Bun command.
 
 ## Conventions
 

--- a/README.md
+++ b/README.md
@@ -211,6 +211,43 @@ bun run dev
 bun run dev --filter=mmss-marcos-app
 ```
 
+The dev server is served by Vite (`vite dev --host`) and listens on `http://localhost:5173` by default. Because it runs with `--host` it is also reachable from other devices on your network.
+
+> **Auth0:** add the dev URL (e.g. `http://localhost:5173`) to your Auth0 application's allowed callback / logout / web origin URLs, otherwise login will fail locally.
+
+### Working in a single workspace
+
+Turborepo runs every workspace by default. To target one, use `--filter` (by package name) or run the script directly in the package with `--cwd`:
+
+```bash
+# Run a root task for one workspace only
+bun run build --filter=mmss-marcos-app
+
+# Run a script defined inside a specific package
+bun run --cwd apps/marcos check        # svelte-check type checking
+bun run --cwd apps/marcos check:watch  # type checking in watch mode
+bun run --cwd apps/marcos preview      # preview a production build
+```
+
+### Before committing
+
+There are no automated tests in CI; quality is enforced by linting, formatting, and type checks. Run these before pushing:
+
+```bash
+bun run lint      # ESLint across all packages
+bun run format    # Prettier
+bun run --cwd apps/marcos check   # Svelte/TypeScript type checking
+```
+
+### Disabling analytics locally
+
+PostHog tracking can be turned off so local activity doesn't pollute analytics. Set these in `apps/marcos/.env`:
+
+```bash
+TRACKING_DISABLED=true         # server-side tracking → NoOp
+PUBLIC_TRACKING_DISABLED=true  # client-side tracking → NoOp
+```
+
 ## Environment Variables
 
 The application requires the following environment variables:

--- a/README.md
+++ b/README.md
@@ -99,8 +99,9 @@ balerial/
 
 ### Prerequisites
 
-- [Bun](https://bun.sh/) 1.x+
-- AWS CLI configured (for deployment)
+- [Node.js](https://nodejs.org/) 22+
+- [Bun](https://bun.sh/) 1.x+ (package manager — do not use npm/yarn/pnpm)
+- AWS CLI configured with credentials (for infrastructure deployment)
 
 ### Installation
 
@@ -108,23 +109,107 @@ balerial/
 # Install dependencies
 bun install
 
-# Start development server
-bun dev
+# Start the dev server
+bun run dev
 
 # Build all packages
-bun build
+bun run build
 ```
+
+> **Note:** Use `bun run <script>` for package scripts. `bun build` (without `run`) invokes Bun's built-in bundler instead of the Turborepo `build` task, so it will not do what you expect. `bun install` is the one exception — it's a built-in Bun command.
 
 ### Available Scripts
 
-| Command             | Description                        |
-| ------------------- | ---------------------------------- |
-| `bun dev`           | Start development mode             |
-| `bun build`         | Build all packages and apps        |
-| `bun lint`          | Lint all packages                  |
-| `bun format`        | Format code with Prettier          |
-| `bun syncpack:list` | List dependency version mismatches |
-| `bun syncpack:fix`  | Fix dependency version mismatches  |
+These scripts are defined at the repo root and run across the workspace via Turborepo:
+
+| Command                  | Description                                          |
+| ------------------------ | ---------------------------------------------------- |
+| `bun install`            | Install all workspace dependencies                   |
+| `bun run dev`            | Start development mode for all apps                  |
+| `bun run build`          | Build all packages and apps                          |
+| `bun run lint`           | Lint all packages                                    |
+| `bun run format`         | Format code with Prettier                            |
+| `bun run update-packages`| Update dependencies across the workspace and reinstall |
+| `bun run skills`         | Install Claude Code skills                           |
+
+## How to Develop
+
+The backoffice app (`apps/marcos`) talks to **real AWS resources** (DynamoDB tables and S3 buckets) — there is no local emulator. To develop locally you therefore need those resources to exist in an AWS account and a set of credentials that are allowed to use them. The high-level flow is:
+
+1. Deploy the CDK infrastructure to an AWS account (creates the tables, buckets, and IAM policies).
+2. Create an AWS access key for a user/role that holds those policies.
+3. Put that key plus the rest of the configuration into `apps/marcos/.env`.
+4. Run the dev server.
+
+### 1. Deploy the CDK environment
+
+The infrastructure lives in `apps/marcos-aws` and is deployed with the AWS CDK. In CI this is automated (see `.github/workflows/aws-deploy-*.yml`), but you can deploy an environment manually.
+
+First, configure AWS credentials for an account/identity that has permission to create the infrastructure (CDK bootstrap, CloudFormation, DynamoDB, S3, IAM, Lambda, EventBridge, SQS). The pipeline deploys to **`eu-central-1`**, so use the same region unless you intend to run a separate environment:
+
+```bash
+export AWS_ACCESS_KEY_ID=...
+export AWS_SECRET_ACCESS_KEY=...
+export AWS_REGION=eu-central-1
+```
+
+The CDK app reads its configuration from environment variables (see `apps/marcos-aws/lib/mmss.app.ts`). All four are **required** or the synth will throw:
+
+| Variable                | Description                                                            |
+| ----------------------- | ---------------------------------------------------------------------- |
+| `CDK_ENV_NAME`          | Environment name, used as a prefix for all resources (e.g. `preview`)  |
+| `ALLOWED_UPLOAD_ORIGINS`| Comma-separated list of origins allowed to upload to S3 (CORS)         |
+| `MAIN_STORE_ID`         | Primary store identifier                                               |
+| `POSTHOG_KEY`           | PostHog server key                                                     |
+
+Then, from `apps/marcos-aws`, run the CDK commands through Bun:
+
+```bash
+cd apps/marcos-aws
+
+# Bootstrap the target account/region (first time only)
+bun run cdk bootstrap
+
+# Preview the changes
+bun run cdk diff
+
+# Deploy the stack
+bun run cdk deploy --all --require-approval never
+```
+
+This creates the DynamoDB tables, S3 buckets, Lambda functions, and — importantly — three IAM **managed policies** that scope access to those resources:
+
+- `${CDK_ENV_NAME}-main-store-read-policy`
+- `${CDK_ENV_NAME}-main-store-write-policy`
+- `${CDK_ENV_NAME}-public-track-orders-policy`
+
+Their ARNs are exported as CloudFormation outputs.
+
+### 2. Get an AWS key with the deployment's role to develop locally
+
+The local app does **not** reuse your deployment credentials. Instead, you need an AWS access key for an IAM user (or role) that has the managed policies created by the CDK deployment attached to it. Without those policies the app cannot read or write the tables/buckets and will fail at runtime.
+
+1. In IAM, create (or pick) a user for local development.
+2. Attach the `${CDK_ENV_NAME}-main-store-read-policy` and `${CDK_ENV_NAME}-main-store-write-policy` managed policies (and `${CDK_ENV_NAME}-public-track-orders-policy` if you are working on the public order tracking flow).
+3. Create an access key for that user — this is the `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` pair the app uses.
+
+The public tracking feature uses a **separate, narrower** credential pair (`TRACK_AWS_ACCESS_KEY_ID` / `TRACK_AWS_SECRET_ACCESS_KEY`) that should only carry the `public-track-orders-policy`.
+
+### 3. Configure the app environment
+
+Create `apps/marcos/.env` and fill in the values produced by the deployment plus the third-party credentials (Auth0, PostHog). The table/bucket names must match those created by CDK for your `CDK_ENV_NAME`. See the [Environment Variables](#environment-variables) section below for the full list.
+
+> SvelteKit reads these via `$env/static/private` and `$env/static/public`, so changes to `.env` require restarting the dev server.
+
+### 4. Run the app
+
+```bash
+# From the repo root
+bun run dev
+
+# …or scope it to just the backoffice app
+bun run dev --filter=mmss-marcos-app
+```
 
 ## Environment Variables
 
@@ -182,19 +267,19 @@ Feature flags are managed via [PostHog](https://posthog.com/) and split into ser
 
 ### AWS Infrastructure (CDK)
 
-Infrastructure deployment is automated via GitHub Actions. To deploy manually:
+Infrastructure deployment is automated via GitHub Actions (`.github/workflows/aws-deploy-*.yml`, deploying to `eu-central-1`). To deploy manually, set the required CDK env vars (`CDK_ENV_NAME`, `ALLOWED_UPLOAD_ORIGINS`, `MAIN_STORE_ID`, `POSTHOG_KEY` — see [How to Develop](#how-to-develop)) and run:
 
 ```bash
 cd apps/marcos-aws
 
 # Bootstrap CDK (first time only)
-cdk bootstrap
+bun run cdk bootstrap
 
 # Preview changes
-cdk diff
+bun run cdk diff
 
 # Deploy infrastructure
-cdk deploy
+bun run cdk deploy --all --require-approval never
 ```
 
 ### Infrastructure Resources


### PR DESCRIPTION
Significantly expand the README and AGENTS.md documentation to provide clearer guidance on local development setup, particularly around AWS infrastructure deployment and credential management.

## Summary

This update clarifies the development workflow for contributors, with emphasis on:
- Proper Bun command usage (`bun run <script>` vs `bun build`)
- Complete AWS CDK deployment instructions for local development
- IAM credential setup for accessing DynamoDB and S3 resources
- Environment variable configuration requirements

## Key changes

- **Prerequisites**: Added Node.js 22+ requirement and clarified Bun as the package manager
- **Installation**: Updated commands to use `bun run dev` and `bun run build` consistently
- **New "How to Develop" section**: Comprehensive 4-step guide covering:
  - CDK environment deployment with required variables (`CDK_ENV_NAME`, `ALLOWED_UPLOAD_ORIGINS`, `MAIN_STORE_ID`, `POSTHOG_KEY`)
  - IAM user/role setup with managed policies for local development
  - `.env` configuration for the marcos app
  - Dev server startup and Auth0 callback URL setup
- **Workspace targeting**: Added examples of using `--filter` and `--cwd` for single-package development
- **Pre-commit checks**: Listed linting, formatting, and type-checking commands
- **Analytics control**: Documented `TRACKING_DISABLED` and `PUBLIC_TRACKING_DISABLED` env vars
- **Bun command clarification**: Added prominent note explaining why `bun run` is required for Turborepo tasks (vs Bun's built-in bundler)
- **AGENTS.md**: Updated command examples to match the `bun run` pattern with the same clarification note

## Notable details

The guide now explicitly documents the separation of deployment credentials (for CDK) from local development credentials (for the app), and the narrower `public-track-orders-policy` for the public order tracking feature. All CDK commands are shown running through Bun (`bun run cdk ...`) for consistency with the monorepo setup.

https://claude.ai/code/session_01HgshZ9DNH1U1iVpFCYoRo8