### PR TITLE
docs: Add comprehensive documentation for pricing, orders, and services

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,12 +88,23 @@ balerial/
 
 | Package                            | Description                                      |
 | ---------------------------------- | ------------------------------------------------ |
-| `@marcsimolduressonsardina/core`   | Core business logic, types, and services         |
+| `@marcsimolduressonsardina/core`   | Core business logic, types, and services ([docs](packages/marcos-core/README.md)) |
 | `@marcsimolduressonsardina/lambda` | Lambda handlers for reports and image processing |
 | `@balerial/s3`                     | S3 utilities (presigned URLs, uploads, tagging)  |
 | `@balerial/dynamo`                 | DynamoDB repository and table abstractions       |
 | `@repo/eslint-config`              | Shared ESLint configuration                      |
 | `@repo/typescript-config`          | Shared TypeScript configuration                  |
+
+## Documentation
+
+In-depth documentation for the core business logic (pricing, orders, services) lives in the `@marcsimolduressonsardina/core` package:
+
+| Document | Description |
+| -------- | ----------- |
+| [Core overview](packages/marcos-core/README.md) | Package architecture, structure, public entry points, and the `ServiceFactory` dependency injection |
+| [Pricing engine](packages/marcos-core/docs/pricing.md) | Price types and formulas, the mold matrix, fabric/crossbar pricing, markup, dimension handling, and validation |
+| [Orders & totals](packages/marcos-core/docs/orders.md) | Order/quote/external lifecycle, calculated items, discounts, totals, payments, and audit trail |
+| [Supporting services](packages/marcos-core/docs/services.md) | Customers, files, reports, config, public receipts, the persistence layer, errors, and logging |
 
 ## Getting Started
 

--- a/packages/marcos-core/README.md
+++ b/packages/marcos-core/README.md
@@ -1,0 +1,171 @@
+# `@marcsimolduressonsardina/core`
+
+Core business logic for **Marcos MMSS**, the order-management and back-office
+system for a custom picture-framing / mold shop. This package is **backend
+framework-agnostic**: it contains the domain types, the pricing engine, the
+order lifecycle, and the persistence layer (DynamoDB + S3). It is consumed by
+the SvelteKit back-office app (`apps/marcos`) and by the Lambda handlers
+(`packages/marcos-lambda-logic`).
+
+It holds **no UI and no HTTP**. Everything is expressed as services that take a
+configuration object and talk to AWS. The SvelteKit app injects these services
+through `locals.services` (see the root `CLAUDE.md`).
+
+---
+
+## What this package does
+
+A customer brings an object (a picture, a jersey, a mirror…) to be framed. A
+shop employee builds an **order** describing:
+
+- the **dimensions** of the work (width × height),
+- an optional **passepartout** (`pp`, the mat border around the work),
+- a list of **parts** to price: a mold (frame), glass, backboard, fabric,
+  labour, hangers, transport, etc.
+
+The package's job is to turn that description into a **price**, persist the
+order, and support the back-office around it (customers, files/photos, audit
+trail, reports, public receipts).
+
+The two pieces worth understanding first are:
+
+1. **The pricing engine** — how each part's price is computed from its
+   dimensions and a configured price formula. → [`docs/pricing.md`](docs/pricing.md)
+2. **The order lifecycle** — how an order is created, priced into a
+   "calculated item", and how totals/discounts/payments work.
+   → [`docs/orders.md`](docs/orders.md)
+
+The remaining services (customers, files, reports, config, order sets, public
+receipts) and the persistence layer are described in
+[`docs/services.md`](docs/services.md).
+
+---
+
+## Package layout
+
+```
+src/
+├── types/            Domain types (Order, Item, ListPrice, Customer, …) — see types/index.ts
+├── service/          The services that contain all the logic
+│   ├── pricing.service.ts            ← price computation entry point
+│   ├── calculated-item.service.ts    ← turns an order's parts into priced parts
+│   ├── order.service.ts              ← order lifecycle + totals
+│   ├── order-set.service.ts          ← grouping orders for a customer
+│   ├── customer.service.ts
+│   ├── file.service.ts               ← photos/attachments on S3
+│   ├── report.service.ts             ← daily/weekly/monthly/dashboard reports
+│   ├── order-audit-trail.service.ts  ← change log per order
+│   ├── config.service.ts             ← store config (locations list)
+│   ├── public-receipt.service.ts     ← read-only public order view
+│   ├── user.service.ts
+│   ├── service-factory.ts            ← lazy DI container for all services
+│   └── dto/order-creation.dto.ts     ← input shape for creating/updating orders
+├── data/             Static pricing data + formulas
+│   ├── static-pricing.ts   ← the pure pricing formula functions
+│   ├── mold-matrix.ts      ← lookup table: small×large side → multiplier
+│   └── mold-price.loader.ts← imports mold base prices from an Excel file in S3
+├── utilities/        Pure helpers (pricing, calculated-item, order, search)
+├── repository/       DynamoDB repositories + DTOs (persistence)
+│   ├── dynamodb/...
+│   ├── dynamodb/table/table.builders.dynamodb.ts ← table + GSI definitions
+│   └── dto/...
+├── configuration/    ICoreConfiguration + helpers
+├── error/            Typed domain errors
+└── logger/           pino logger factory
+```
+
+### Public entry points (`package.json` → `exports`)
+
+| Import path | Resolves to | Contains |
+|---|---|---|
+| `.../core/service` | `src/service/index.ts` | All services + `ServiceFactory` |
+| `.../core/type`    | `src/types/index.ts` | All domain types & enums |
+| `.../core/dto`     | `src/service/dto/order-creation.dto.ts` | Order creation DTOs |
+| `.../core/util`    | `src/utilities/index.ts` | Pricing/calculated-item/order/search utilities |
+| `.../core/db`      | `src/repository/dynamodb/table/table.builders.dynamodb.ts` | Table builders for infra |
+| `.../core/config`  | `src/configuration/core-configuration.interface.ts` | Config interfaces |
+| `.../core/data`    | `src/data/mold-price.loader.ts` | Excel mold-price loader |
+| `.../core/error`   | `src/error/index.ts` | Domain errors |
+| `.../core/logger`  | `src/logger/logger.ts` | Logger factory |
+
+---
+
+## Architecture at a glance
+
+```
+            ┌─────────────────────────────────────────────┐
+            │              ServiceFactory                  │  lazy DI, one per request
+            └─────────────────────────────────────────────┘
+                 │ creates & wires (singletons within a request)
+     ┌───────────┼───────────────┬───────────────┬──────────────┐
+     ▼           ▼               ▼               ▼              ▼
+ OrderService  PricingService  CustomerService  FileService  ReportService …
+     │              ▲
+     │ depends on   │
+     ▼              │
+ CalculatedItemService ──── uses ──┘   (PricingService computes each part)
+     │
+     ▼
+ DynamoDB repositories  ──►  AWS DynamoDB / S3
+```
+
+- **Services are stateless** beyond their injected config and collaborators.
+  They are created lazily by `ServiceFactory` and re-wired per request, so they
+  must never be shared across stores.
+- **Repositories** wrap `@balerial/dynamo` and translate **DTOs** (the shape
+  stored in DynamoDB) ↔ **domain types** (the shape used in code). Every
+  service owns this `toDto`/`fromDto` boundary.
+- **`storeId`** scopes nearly everything to a single shop. A special
+  `'public-repo'` store powers the public, read-only receipt flow
+  (`PublicServiceFactory`).
+
+### Configuration
+
+Services are constructed from an `ICoreConfiguration` (browser/server, carries
+explicit AWS `region` + `credentials`) or `ICoreConfigurationForAWSLambda`
+(runs inside Lambda, credentials come from the execution role). The config also
+carries all table/bucket names, the current `user`, and feature switches like
+`disableOrderAuditTrail`. See `src/configuration/core-configuration.interface.ts`.
+
+### The `ServiceFactory`
+
+`ServiceFactory.create(config)` (or `.createForLambda`) is the single
+entry point. Each service is exposed via a lazy getter that builds the
+dependency graph on first access — e.g. `orderService` pulls in
+`customerService`, `calculatedItemService`, `pricingService` and
+`orderAuditTrailService`.
+
+There are also **markup-aware factories** (`createOrderServiceWithMarkup`,
+`createPricingServiceWithMarkup`, …) used for *external* orders where a
+percentage markup is layered on top of the base catalog prices. See the markup
+section in [`docs/pricing.md`](docs/pricing.md).
+
+`ServiceFactory.createPublic(config)` returns a `PublicServiceFactory` exposing
+only the read-only services needed for the public receipt page.
+
+---
+
+## Conventions used throughout
+
+- **Money** is rounded to cents; most formulas round **up** (`Math.ceil`) at
+  the last step so the shop never under-charges. Some round to the nearest
+  10 cents (`*10)/10`). The exact rounding per formula is documented in
+  [`docs/pricing.md`](docs/pricing.md).
+- **Dimensions** are in **centimetres**. Formulas that work in m² divide by 100
+  per side.
+- **IDs**: domain objects use `id` (a UUID); DTOs persist it as `uuid`. Price
+  list entries additionally have a human/business `id` (e.g. a mold reference)
+  and an `internalId` (the UUID).
+- **Spanish UI text** lives in descriptions (e.g. `'Estirar tela'`,
+  `'Cantoneras'`, `'Travesaño'`) because it surfaces directly in the UI.
+
+---
+
+## Further reading
+
+| Doc | Covers |
+|---|---|
+| [`docs/pricing.md`](docs/pricing.md) | Price types, formulas, the mold matrix, fabric/crossbar, markup, dimension handling, validation |
+| [`docs/orders.md`](docs/orders.md)   | Order/quote/external-order lifecycle, calculated items, discounts, totals, payments, audit trail |
+| [`docs/services.md`](docs/services.md) | Customers, files, reports, order sets, config, public receipts, repositories, errors |
+</content>

--- a/packages/marcos-core/docs/orders.md
+++ b/packages/marcos-core/docs/orders.md
@@ -1,0 +1,254 @@
+# Orders, calculated items & totals
+
+How an order goes from "an employee filled a form" to a persisted, priced
+order with running totals and a full change history.
+
+Key files:
+
+- **`src/types/order.type.ts`** — `Order`, `Item`, `CalculatedItem`, totals,
+  enums.
+- **`src/service/order.service.ts`** — lifecycle + totals.
+- **`src/service/calculated-item.service.ts`** — pricing each part into a
+  `CalculatedItem`.
+- **`src/service/order-audit-trail.service.ts`** — per-order change log.
+- **`src/service/dto/order-creation.dto.ts`** — input shape.
+
+---
+
+## 1. The domain model
+
+### `Item` — what is being framed
+The physical description an employee enters:
+
+```ts
+Item {
+  width, height          // cm, the work itself
+  pp                     // uniform passepartout border (cm)
+  ppDimensions?          // { up, down, left, right } overrides uniform pp
+  floatingDistance       // gap for "floating" mounting
+  dimensionsType         // NORMAL | EXTERIOR | ROUNDED | WINDOW
+  exteriorWidth/Height?  // when measuring the outer frame instead of the work
+  description, observations, predefinedObservations[]
+  quantity               // how many identical units
+  deliveryDate, instantDelivery
+  partsToCalculate: PreCalculatedItemPart[]   // ← the things to price
+}
+```
+
+A **`PreCalculatedItemPart`** is a request to price one part:
+`{ type: PricingType, id, quantity, moldId?, extraInfo? }`. `moldId` is only for
+fabric crossbars (links to the mold whose price drives the crossbar);
+`extraInfo` is free text folded into the description (e.g. a passepartout note).
+
+### `Order` — the business object
+Wraps an `Item` with customer, store, user, status, payment and identifiers:
+
+```ts
+Order {
+  id           // UUID
+  shortId      // nanoid(10), used internally
+  publicId     // "DDMMYYYY/XX/<phone>" — shareable receipt id
+  storeId, user, customer
+  createdAt, status
+  amountPayed, invoiced, notified, hasArrow, location
+  item: Item
+}
+```
+
+### `OrderStatus`
+`PENDING` → `FINISHED` → `PICKED_UP`, plus `QUOTE` (a saved estimate, not a real
+order) and `DELETED`. Quotes use a sentinel delivery date `31/12/9999`
+(`quoteDeliveryDate`).
+
+### `ExternalOrder`
+A leaner order for external/wholesale pricing. It has a `reference` instead of a
+customer and is **not persisted** the same way — `createExternalOrderFromDto`
+computes and returns it (with markup) but does not write an order row. Its
+`reference` encodes the totals: `"<total>/<markup>/<totalWithoutMarkup>"`.
+
+---
+
+## 2. From form to priced order
+
+The SvelteKit app submits an **`OrderCreationDto`** (the `Item` fields + a
+`customerId?`, `discount`, `extraParts`, `isQuote`, `hasArrow`,
+`dimensionsType`, …). `OrderService.createOrderFromDto`:
+
+1. Resolves the customer (`customerId`), or falls back to the **temp customer**
+   (`tempCustomerUuid`, phone `+34612345678`) for walk-ins not yet identified.
+2. `generateOrderAndCalculatedItemFromDto`:
+   - Builds the `Order` (new UUID, status = `QUOTE` if `isQuote` else
+     `PENDING`).
+   - **`optimizePartsToCalculate`** de-duplicates parts: identical
+     `type_id_moldId_extraInfo` combos are merged and their quantities summed.
+   - Generates `shortId` (`nanoid(10)`) and `publicId`
+     (`DDMMYYYY/<2 random>/<phone>`), and validates the item
+     (`verifyItem` — quantity and every part's `id/quantity/type` required).
+   - Calls `CalculatedItemService.createCalculatedItem` to price every part.
+3. Persists **in parallel**: the order row, the calculated item, and an audit
+   trail "status changed" entry.
+4. Returns a **`FullOrder`** = `{ order, calculatedItem (with part types),
+   totals }`.
+
+`updateOrderFromDto` is similar but preserves the original
+`id/shortId/createdAt/status/location/amountPayed/notified/user/publicId`, and
+logs a **full data-diff** audit entry instead of a status change. Note: an
+update **re-creates** the order row (`repository.createOrder`) — there is no
+partial patch for the item.
+
+---
+
+## 3. CalculatedItem — pricing the parts
+
+`CalculatedItemService.createCalculatedItem(order, discount, extraParts)`:
+
+1. Computes `OrderDimensions` once from the item
+   (`CalculatedItemUtilities.getOrderDimensions`).
+2. Prices each `PreCalculatedItemPart` **in parallel** via `calculatePart` →
+   `PricingService.calculatePrice` (see [`pricing.md`](pricing.md)).
+3. Appends any **`extraParts`** (manually-added lines, e.g. corners) verbatim.
+
+A priced **`CalculatedItemPart`**:
+
+```ts
+{ priceId, price, quantity, discountAllowed, floating, description, log? }
+```
+
+`description` is derived per type by `getDefaultDescriptionByType` (e.g.
+`"Cristal <id>"`, `"Trasera <id>"`, `"Passepartout <id>"`, `"Montaje <id>"`,
+mold → `getMoldDescription`). A custom description overrides the default;
+`extraInfo` is appended in parentheses.
+
+The `CalculatedItem` (`{ orderId, discount, parts[], quantity }`) is persisted
+separately from the order, keyed by `orderId`.
+
+### Extra parts helper
+`CalculatedItemUtilities.getCornersPricing(userMarkup)` builds the "Cantoneras"
+(corner protectors) part at `2.5 €` (× markup if any), id `cantoneras_extra`.
+`otherExtraId = 'other_extra'` tags generic manual lines.
+
+---
+
+## 4. Totals, discounts & payments
+
+`OrderService.getTotals(calculatedItem)` (via
+`CalculatedItemUtilities.calculatePartsCost`):
+
+```
+discountFactor      = applyDiscount ? (1 - discount/100) : 1
+perPart             = price * quantity * (discountAllowed ? discountFactor : 1)
+unitPrice           = ceil( Σ perPart(with discount)    * 100 ) / 100
+unitPriceNoDiscount = ceil( Σ perPart(without discount) * 100 ) / 100
+total               = unitPrice * item.quantity
+totalWithoutDiscount= unitPriceNoDiscount * item.quantity
+discountNotAllowedPresent = (some part has discountAllowed=false) && discount>0
+```
+
+- **Discount** is a percentage on the whole item, but parts flagged
+  `discountAllowed = false` are **excluded** from the discount.
+  `discountNotAllowedPresent` lets the UI warn that the discount didn't apply to
+  everything.
+- **`item.quantity`** multiplies the per-unit price for identical units.
+
+`getTotalsForOrder` adds payment state:
+- `remainingAmount = total - amountPayed`
+- `payed = remainingAmount <= 0`
+
+`getTotalsForExternalOrder` adds `markup` and
+`totalWithoutMarkup = pricingService.calculatePriceWithoutMarkup(total)`.
+
+### Payment operations
+- `setOrderFullyPaid(order)` → `amountPayed = total`, logs a payment entry.
+- `setOrderPartiallyPaid(order, amount)` → clamps `amount` to `[0, total]`
+  (negative throws `InvalidDataError`), logs payment.
+
+`PaymentStatus` (`FULLY_PAID | PARTIALLY_PAID | UNPAID`) is the enum the UI maps
+to from these numbers.
+
+---
+
+## 5. Status transitions
+
+| Method | Effect |
+|---|---|
+| `setOrderStatus(order, status, location?)` | Sets status + location; logs status and location changes. |
+| `setOrderAsNotified(order)` | Marks `notified = true`; logs a notification entry. |
+| `setOrderInvoiced(order, invoiced)` | Toggles `invoiced` (no audit entry). |
+| `moveQuoteToOrder(order, deliveryDate)` | `QUOTE → PENDING`: resets `createdAt`, sets user + delivery date; logs. |
+| `moveOrderToQuote(order)` | `* → QUOTE`: resets `createdAt`, delivery date → `31/12/9999`, clears `notified` and `amountPayed`; logs. |
+| `addCustomerToTemporaryOrder(customer, order)` | Replaces the temp customer on a walk-in order. Throws if the order isn't temp. |
+
+`OrderService.validateOrderId(id)` validates a UUID before any lookup.
+
+---
+
+## 6. Reads & queries
+
+`OrderService` exposes many read paths, all of which hydrate the customer and
+(for `FullOrder`) the calculated item + totals:
+
+- By id: `getOrderById`, `getOrdersByIds`, `getFullOrderById`,
+  `getFullOrdersByIds`.
+- By public id: `getOrderIdByPublicId`.
+- By status: `getOrdersByStatus`, `getStandaloneOrdersByStatus`,
+  `getOrdersByStatusPaginated`, `findOrdersByStatus(status, query)` (text search
+  via `SearchUtilities.normalizeString`).
+- By customer: `getOrdersByCustomerId` (excludes quotes),
+  `getOrdersByCustomerIdAndStatus`.
+- Same-day grouping: `getOrdersOnSameDay`, `getOrdersCountOnSameDay`
+  (`ISameDayOrderCounters` = finished/pending/total) — used to group a
+  customer's orders made the same day.
+
+`getFullOrders` batch-loads calculated items for a list of orders and zips them
+with totals, attaching `PricingType` back onto each part
+(`addTypesToCalculatedItem`) by matching `priceId` to the original
+`partsToCalculate`.
+
+---
+
+## 7. Order sets
+
+`OrderSetService` groups several of **one customer's** orders into a single set
+(e.g. to print/share them together).
+
+- `createOrderSet(orderIds)`: loads the full orders, **asserts they share one
+  customer** (else throws), computes a deterministic **SHA-256 hash** of the
+  sorted ids, and is **idempotent** — if a set with the same hash exists it is
+  returned instead of creating a duplicate.
+- `getOrderSetById(id)` rehydrates the set with its full orders.
+
+The hash (sorted ids → `sha256`) is both the dedupe key and a stable identifier.
+
+---
+
+## 8. Audit trail
+
+`OrderAuditTrailService` records every meaningful change, keyed by order, with
+`userId/userName` and timestamp. Types (`OrderAuditTrailType`):
+`STATUS`, `LOCATION`, `NOTIFICATION`, `PAYMENT`, `ATTACHMENT`, `DATA`.
+
+- Simple entries store `oldValue`/`newValue` scalars (status, amount, location,
+  file ref).
+- **`DATA`** entries (`logOrderFullChanges`) store the entire old and new
+  `Order` (serialised via `OrderService.toDto`). They are skipped if the order
+  is unchanged (`JSON.stringify` equality) or the ids differ.
+- All writes are **suppressed** when `config.disableOrderAuditTrail === true`,
+  or when `newValue === oldValue`.
+- `getEntriesForOrder(orderId, type?)` and
+  `getEntriesForDayWithoutDataType(date)` (used by reporting) are the reads. The
+  daily query intentionally excludes bulky `DATA` entries.
+
+These status entries are the raw material the **daily report** mines to detect
+"order became `PENDING` today" (see [`services.md`](services.md) → Reports).
+
+---
+
+## 9. The temp customer
+
+Walk-ins without identification get a synthetic customer
+(`OrderService.getTempCustomer`): id `temp-customer`, name `"Temp"`, phone
+`+34612345678`. `OrderUtilities.isOrderTemp(order)` checks for it, and
+`addCustomerToTemporaryOrder` later swaps in the real customer. Read paths
+inject the temp customer into their customer maps so temp orders hydrate
+correctly.
+</content>

--- a/packages/marcos-core/docs/pricing.md
+++ b/packages/marcos-core/docs/pricing.md
@@ -1,0 +1,385 @@
+# Pricing engine
+
+This is the heart of the package: how the price of a framing order is computed.
+Everything here lives in three places:
+
+- **`src/service/pricing.service.ts`** — orchestration: load a price entry,
+  pick the right dimensions, apply the right formula, enforce limits, apply
+  markup.
+- **`src/data/static-pricing.ts`** — the pure formula functions (the actual
+  maths) plus the `getMoldPrice` matrix lookup.
+- **`src/utilities/pricing.utilites.ts`** — shared constants and helpers
+  (`fabricIds`, formula groupings, crossbar helpers).
+
+The price data itself lives in DynamoDB as **`ListPrice`** rows, one per
+catalog entry (a specific mold, a glass type, a labour line, …). Mold rows are
+bulk-loaded from an Excel file (see [Mold prices](#mold-prices-the-matrix--excel-loader)).
+
+---
+
+## 1. The vocabulary
+
+### Pricing types — `PricingType` (`src/types/pricing.type.ts`)
+
+Each part of an order belongs to exactly one pricing type. The type decides
+**which dimensions** are used and **which pricing path** runs.
+
+| Type | Meaning (Spanish UI) | Pricing path |
+|---|---|---|
+| `MOLD` | Moldura (frame) | Matrix lookup (`getMoldPrice`) |
+| `FABRIC` | Estirar tela / Travesaño (stretch fabric / crossbar) | Special fabric path |
+| `GLASS` | Cristal | Formula |
+| `BACK` | Trasera (backboard) | Formula |
+| `PP` | Passepartout (mat) | Formula |
+| `LABOUR` | Montaje (assembly) | Formula |
+| `TRANSPORT` | Transporte | Formula (usually `NONE`) |
+| `HANGER` | Colgador | Formula (usually `NONE`) |
+| `OTHER` | Otros | Formula (usually `NONE`) |
+
+### Pricing formulas — `PricingFormula`
+
+The formula tells the engine how to turn a base price + dimensions into a final
+price. Used by every type **except** `MOLD` and `FABRIC`, which have dedicated
+paths.
+
+| Formula | Function | Idea |
+|---|---|---|
+| `FORMULA_LINEAR` | `linearPricing` | Price per metre of **perimeter** |
+| `FORMULA_LINEAR_SHORT_SIDE` | `linearPricingShortSide` | Price per metre of the **short side** |
+| `FORMULA_AREA` | `areaPricing` | Price per **m²** (raw) |
+| `FORMULA_LEFTOVER` | `leftoverPricing` | m² price with waste factor **5** + tax |
+| `FORMULA_LEFTOVER_12` | `leftoverPricing12` | same with waste factor **12** |
+| `FORMULA_FIT_AREA` | `fitAreaPricing` | Step table: smallest `MaxArea` that fits |
+| `FORMULA_FIT_AREA_M2` | `fitAreaM2Pricing` | Step table by m² (`MaxAreaM2`) |
+| `NONE` | — | Flat price, returned as-is |
+
+### `ListPrice` — a catalog entry
+
+```ts
+type ListPrice = {
+  id: string;            // business id (e.g. mold reference "1234_ABC")
+  internalId: string;    // UUID (persisted as `uuid`)
+  price: number;         // base price; meaning depends on the formula
+  minPrice: number;      // floor applied to the final computed price
+  discountAllowed: boolean;
+  description: string;   // Spanish, shown in UI
+  type: PricingType;
+  formula: PricingFormula;
+  areas: MaxArea[];       // for FORMULA_FIT_AREA  → { d1, d2, price }
+  areasM2: MaxAreaM2[];   // for FORMULA_FIT_AREA_M2 → { a, price }
+  priority: number;
+  floating: boolean;      // mold can be hung "floating"; informational flag
+  maxD1?: number;         // max long side (cm) allowed
+  maxD2?: number;         // max short side (cm) allowed
+};
+```
+
+`price` is overloaded by formula: for `FORMULA_AREA`/`LEFTOVER*` it is a **price
+per m²**; for `LINEAR*` a **price per metre**; for `MOLD` a **per-unit base**
+multiplied by the matrix factor; for `NONE` the **final flat price**. For the
+`FIT_AREA*` formulas `price` is forced to `0` and the price comes from the
+`areas`/`areasM2` step table.
+
+---
+
+## 2. Dimensions — what the formulas actually receive
+
+Computed in `CalculatedItemUtilities.getOrderDimensions`
+(`src/utilities/calculated-item.utilites.ts`) from the order's `width`,
+`height`, `pp`, and optional per-side `ppDimensions`.
+
+```
+OrderDimensions {
+  originalWidth, originalHeight   // as entered
+  totalWidth, totalHeight         // original + passepartout
+  workingWidth, workingHeight     // total rounded UP to the next multiple of 5
+}
+```
+
+- **Total** = original + passepartout border.
+  - Uniform: `total = original + 2 * pp` on each axis.
+  - Per side: `totalWidth = width + left + right`,
+    `totalHeight = height + up + down`.
+- **Working** = each total dimension rounded **up to the nearest multiple of 5**
+  (`roundUpToNearestGreaterFiveOrTen`). A value already on a multiple of 5 is
+  left unchanged. These are the dimensions used to cut material, hence used for
+  molds.
+
+### Which dimensions each path uses
+
+`PricingService` normalises dimensions into an ordered `{ d1, d2 }` pair where
+`d1 = max`, `d2 = min`:
+
+- **Working dimensions** (`cleanAndOrderWorkingDimensions`) are **floored** to
+  whole cm: `{ d1: floor(max), d2: floor(min) }`.
+- **Total dimensions** (`cleanAndOrderTotalDimensions`) are **not** floored.
+
+The mapping (`getDimensionsByType` / `getDimensionsByFormula`):
+
+| Path | Dimensions used |
+|---|---|
+| `MOLD`, `FABRIC` | **Working** (floored) |
+| `FORMULA_LEFTOVER`, `FORMULA_LEFTOVER_12` | **Working** (floored) |
+| `FORMULA_FIT_AREA`, `FORMULA_FIT_AREA_M2`, `FORMULA_AREA`, `FORMULA_LINEAR`, `FORMULA_LINEAR_SHORT_SIDE`, `NONE` | **Total** (not floored) |
+
+> Note: the fabric **crossbar** sub-case explicitly uses **total** dimensions
+> even though `FABRIC` is otherwise a working-dimension type — see
+> [Fabric & crossbar](#5-fabric--crossbar-pricing).
+
+---
+
+## 3. The pricing entry point — `calculatePrice`
+
+```ts
+calculatePrice(pricingType, orderDimensions, id, moldFabricId?) → {
+  price, description, discountAllowed, floating
+}
+```
+
+Steps:
+
+1. **Load the price entry.**
+   - `FABRIC` → `getFabricPriceList(...)` (special, see below).
+   - otherwise → `getPriceFromListById(type, id)` which reads the DynamoDB row
+     by `(type, id)` and **applies markup** (section 7).
+2. **Enforce dimension limits** — `checkMaxMinDimensions` (section 6).
+3. **Compute the raw price** — `getPriceByType` dispatches on `type`:
+   - `MOLD` → `getMoldPrice`
+   - `FABRIC` → `getFabricPrice`
+   - everything else → `getPriceByFormula`
+4. **Apply the floor**: `Math.max(rawPrice, minPrice)`.
+
+The returned object carries `description`, `discountAllowed` and `floating`
+through to the calculated part.
+
+---
+
+## 4. The formula functions (`static-pricing.ts`)
+
+All maths is in pure functions. `defaultTax = 1.21` (21% IVA) is baked into the
+leftover formulas. Unless stated otherwise, `d1`/`d2` are in **cm**.
+
+### `linearPricing(mPrice, d1, d2)` — `FORMULA_LINEAR`
+Perimeter in metres × price-per-metre, rounded up to cents.
+```
+((d1/100 + d2/100) * 2) * mPrice   → ceil to cents
+```
+
+### `linearPricingShortSide(mPrice, d1, d2)` — `FORMULA_LINEAR_SHORT_SIDE`
+Short side in metres × price-per-metre, rounded up to cents.
+```
+(min(d1, d2) / 100) * mPrice        → ceil to cents
+```
+
+### `areaPricing(m2Price, d1, d2)` — `FORMULA_AREA`
+Plain area in m² × price-per-m², rounded up to cents.
+```
+(d1/100) * (d2/100) * m2Price        → ceil to cents
+```
+
+### `leftoverPricing(m2Price, d1, d2)` / `leftoverPricing12(...)` — `FORMULA_LEFTOVER[_12]`
+Area-based but with a **waste multiplier** (`5` or `12`), the **21% tax**, a
+floor of 15 cm per side, and a flat **+2** handling charge. Rounded up to the
+nearest **10 cents**.
+```
+d1m = max(15, d1);  d2m = max(15, d2)
+((d1m/100) * (d2m/100) * m2Price * 1.21 * factor) + 2   → ceil to 0.1
+```
+`leftoverPricing` uses `factor = 5`; `leftoverPricing12` uses `factor = 12`.
+These model materials sold in larger sheets where offcuts are wasted.
+
+### `fitAreaPricing(listPrice, d1, d2)` — `FORMULA_FIT_AREA`
+A **step table** of `MaxArea { d1, d2, price }` rows. The rows are sorted by
+area, then perimeter (`sortByAreaAndPerimeter`); the engine returns the price of
+the **first row that fully contains** the requested size (`row.d1 >= d1 &&
+row.d2 >= d2`). If none fits → `InvalidSizeError` (Spanish message). Empty table
+→ `InvalidSizeError`.
+
+### `fitAreaM2Pricing(listPrice, d1, d2)` — `FORMULA_FIT_AREA_M2`
+A step table of `MaxAreaM2 { a, price }` keyed by **area in m²**. The requested
+area is `ceil((d1/100)*(d2/100) * 100)/100` (m², rounded up to cents). Rows are
+sorted ascending by `a`; returns the price of the **first row whose `a >=`
+requested area**. None fits / empty → `InvalidSizeError`.
+
+### `NONE`
+Returns `listPrice.price` unchanged (a flat price). Common for transport,
+hangers and one-off "other" lines.
+
+---
+
+## 5. Fabric & crossbar pricing
+
+Fabric is special: stretching a textile (`'fabric'`) is priced from working
+dimensions, while a **crossbar** (`'fabric_long'` / `'fabric_short'`,
+"travesaño") is priced from a referenced **mold's** base price and one of the
+**total** dimensions.
+
+Fabric ids (`PricingUtilites.fabricIds`):
+
+```ts
+fabricIds = { labour: 'fabric', short: 'fabric_short', long: 'fabric_long' }
+```
+
+### Loading the price entry — `getFabricPriceList(id, dims, moldFabricId?)`
+- `id === 'fabric'` (labour) → returns the in-code `fabricDefaultPricing`
+  entry ("Estirar tela", `NONE`, max 300×250). No DB lookup.
+- otherwise (a crossbar) → `moldFabricId` is **required**. It loads the
+  referenced **mold** price, then builds a synthetic `ListPriceWithMold` via
+  `PricingUtilites.generateCrossbarPricing(...)`, whose description is
+  `"Travesaño (<mold desc>) <dimension>cm"`. Markup is then applied.
+
+### Computing the fabric price — `getFabricPrice(priceInfo, dims)`
+- **Labour** (`id === 'fabric'`) → `getFabricPrice(d1, d2)` on **working** dims:
+  ```
+  ceil((0.0308 * (d1 + d2) + 1.95) * 10) / 10   // linear in (width+height), to 10 cents
+  ```
+- **Crossbar** → `getCrossbarPrice(moldPrice, dimension)` where `dimension`
+  comes from **total** dims via `getFabricCrossbarDimension`:
+  - `'fabric_long'` → uses `max(d1, d2)`
+  - `'fabric_short'` (or other) → uses `min(d1, d2)`
+  ```
+  getCrossbarPrice(mPrice, d) = ceil(((d/100) * mPrice + 3) * 100) / 100
+  ```
+  i.e. the chosen side in metres × the mold's base price, **+3** flat, to cents.
+
+---
+
+## 6. Mold prices — the matrix + Excel loader
+
+Molds do **not** use a formula. Their price is:
+
+```
+getMoldPrice(basePrice, d1, d2):
+  factor = moldMatrix[ max(10, min(d1,d2)) ][ max(d1,d2, 15) ]
+  return ceil(factor * basePrice * 100) / 100
+```
+
+- `moldMatrix` (`src/data/mold-matrix.ts`) is a 2-D lookup
+  `Record<shortSide, Record<longSide, multiplier>>`. The **short side is clamped
+  to ≥10 cm** and the **long side to ≥15 cm** before lookup.
+- The multiplier grows with size (more linear metres + more waste for bigger
+  frames). If a cell is missing the function throws `"Mold factor not found"`.
+- `basePrice` is the per-mold catalog price (price per "unit" of the matrix),
+  stored on the mold's `ListPrice` row.
+
+Working dimensions (floored) are used.
+
+### Excel bulk loader — `MoldPriceLoader` (`src/data/mold-price.loader.ts`)
+
+Mold catalog prices are maintained in a spreadsheet, not hand-entered. The
+loader:
+
+1. `generateFileUploadUrl()` → a presigned S3 URL to upload an `.xlsx` into the
+   `moldPricesBucket`.
+2. `loadMoldPrices(fileName)`:
+   - reads the **`TODAS`** sheet,
+   - for each row: column **A** = internal id / location (UBI), **B** = external
+     id, **C** = price, **D** = floating (`'S'` → `true`),
+   - builds `ListPrice` rows with `id = "<A>_<B>"`, description
+     `"<B> UBI: <A>"`, type `MOLD`, formula `NONE`, price ceil-ed to cents,
+   - **deletes all existing mold prices and replaces them** with the new set
+     (`deleteListPrices` then `batchStoreListPrices`).
+
+The mold `id` encodes location + reference; `CalculatedItemUtilities.getMoldDescription`
+splits it back into `"<reference> - UBI: <location>"` for display.
+
+---
+
+## 7. Markup (external orders)
+
+`PricingService` is constructed with an optional `markup` percentage:
+
+```ts
+new PricingService(config, markup)   // markup stored internally as markup/100
+```
+
+When `markup > 0`, every price loaded from the catalog is inflated **before**
+the formula runs, by `getPriceWithMarkup` / `calculateMarkup`:
+
+```
+calculateMarkup(p)            = round(p * (1 + markup) * 100) / 100
+calculatePriceWithoutMarkup(p)= round((p / (1 + markup)) * 100) / 100
+```
+
+Markup is applied to `price`, `minPrice`, and every `areas[].price` /
+`areasM2[].price`. With `markup === 0` the price object is returned untouched.
+
+This is used for **external orders** (orders for non-walk-in / wholesale
+contexts) where a percentage is layered over the base catalog. The factories
+`ServiceFactory.createPricingServiceWithMarkup` /
+`createCalculatedItemServiceWithMarkup` / `createOrderServiceWithMarkup` build a
+fully-wired stack at a given markup. The external order's totals then expose
+both `total` (with markup) and `totalWithoutMarkup` (back-computed via
+`calculatePriceWithoutMarkup`). See [`orders.md`](orders.md).
+
+---
+
+## 8. Dimension limits & validation
+
+### `checkMaxMinDimensions(orderDimensions, pricing)`
+Run before computing every price.
+
+- **Skipped** when `formula === NONE` **and** the type is in
+  `noDimensionCheckPricingTypes` = `[OTHER, TRANSPORT, HANGER]` (these are size
+  independent).
+- Otherwise, if the entry has `maxD1`/`maxD2`, the relevant `{d1,d2}` (by type)
+  is compared against the ordered max pair. If either side exceeds its max →
+  **`InvalidSizeError`** with a Spanish message including the description, id and
+  allowed `d1×d2`.
+
+Molds are clamped at **300×265** (set in `cleanAndVerifyEntity`); the in-code
+fabric labour entry caps at **300×250**.
+
+### `cleanAndVerifyEntity(listPrice)` — write-time normalisation
+Runs on `createPricing` / `updatePricing` / `batchStoreListPrices` before
+persisting:
+
+- `FORMULA_FIT_AREA` **requires** `areas`; `FORMULA_FIT_AREA_M2` **requires**
+  `areasM2` (else throws).
+- Non-fit formulas **require** a `price` (`price >= 0`, except `MOLD` may be
+  negative); fit formulas force `price = 0` and clear the non-relevant
+  area arrays.
+- `MOLD` is forced to `maxD1 = 300`, `maxD2 = 265`, `formula = NONE`.
+
+`fitFormulas = [FORMULA_FIT_AREA, FORMULA_FIT_AREA_M2]` is the canonical set
+used for these branches.
+
+---
+
+## 9. Persistence of prices — `ListPricingRepositoryDynamoDb`
+
+`ListPrice` ⇄ `ListPriceDto` (`{ uuid, id, type, formula, price, areas, … }`).
+The table has a **GSI by `type`** (`ListPricingSecondaryIndexNames.Type`):
+
+- `getByTypeAndId(type, id)` → the catalog entry for a part.
+- `getByInternalId(uuid)` → by primary key (the UUID).
+- `getAllPricesByType(type)` → the whole sub-catalog (e.g. all glass).
+- `storeListPrice` / `batchStoreListPrices` **enforce id uniqueness** within a
+  type: storing an `id` that already exists under a different `uuid` throws
+  `InvalidKeyError`.
+- `deleteListPrices(uuids)` → batch delete by primary key.
+
+`PricingService.getPricingList(type)` / `getPriceListByInternalId(id)` are the
+read APIs used by the back-office price-management screens, returning prices
+**with markup applied** (markup is `0` for the normal store factory).
+
+---
+
+## 10. Worked example
+
+A 50 × 70 cm picture, 5 cm passepartout all around, with a mold, glass, and
+backboard.
+
+1. **Dimensions** (`getOrderDimensions(70, 50, 5)`):
+   - total = `(70 + 2·5) × (50 + 2·5)` = **80 × 60** (long × short after ordering).
+   - working = round-up-to-5 of each = **80 × 60** (already multiples of 5).
+2. **Mold** (base price say 4.00 €/unit): working ordered `{d1:80, d2:60}` →
+   `factor = moldMatrix[60][80]` → `ceil(factor * 4.00 * 100)/100`.
+3. **Glass** with `FORMULA_AREA` at 30 €/m², total dims `{80,60}`:
+   `ceil((0.80 · 0.60 · 30) * 100)/100 = ceil(14.40) = 14.40 €`.
+4. **Backboard** with `FORMULA_FIT_AREA`: the smallest configured `MaxArea`
+   whose `d1 ≥ 80 && d2 ≥ 60` supplies the price.
+5. Each result is floored by its own `minPrice`, markup is applied (0 for a
+   normal store), and the three become **calculated parts** that the order's
+   totals sum up (see [`orders.md`](orders.md)).
+</content>

--- a/packages/marcos-core/docs/services.md
+++ b/packages/marcos-core/docs/services.md
@@ -1,0 +1,200 @@
+# Supporting services, persistence, errors
+
+The pricing engine ([`pricing.md`](pricing.md)) and order lifecycle
+([`orders.md`](orders.md)) are the core. This document covers everything around
+them: customers, files, reports, config, public receipts, the persistence
+layer, and the error/logging utilities.
+
+---
+
+## Customers — `CustomerService`
+
+CRUD + search for shop customers (`{ id, storeId, name, phone }`).
+
+- `createCustomer(name, phone)` / `updateCustomerData(customer, name?, phone?)`
+  validate via `CustomerService.validate`:
+  - name and phone required (non-empty),
+  - phone must match `^\+\d{1,3}\d{9,15}$` (E.164-ish: leading `+`, country
+    code, 9–15 digits) — else `InvalidDataError`.
+- Reads: `getCustomerById`, `getCustomersByIds` (de-duped batch → map),
+  `getCustomerByPhone`, `searchCustomers(query)` (normalised text search),
+  `getAllCustomersPaginated(nextKey)`.
+- `indexCustomers()` re-reads every customer and re-writes it, refreshing the
+  persisted `normalizedName` search field (a maintenance / re-index op).
+- `deleteCustomerById(id)`.
+
+Persistence: primary key `uuid`, plus a **`store` GSI** on
+`(storeId, phone)` enabling phone lookups within a store.
+
+---
+
+## Files & photos — `FileService`
+
+Manages attachments (photos, videos, other docs, or an explicit "no artwork"
+marker) for an order, stored in S3 (`filesBucket`) via
+`@balerial/s3`'s `BalerialCloudFileService`.
+
+- **Upload**: `createFile(orderId, fileName, variant?)` infers the MIME type
+  (`mime-types`), classifies it (`classifyMimeType` → `PHOTO` / `VIDEO` /
+  `OTHER`), generates a storage key
+  (`<orderId>/<type>/<fileId>.<ext>`, photos prefixed by variant
+  `original/` or `optimized/`), returns a **presigned upload URL** (300 s) with
+  metadata (`store_id`, `order_id`, `file_id`, `type`), and logs an audit
+  `ATTACHMENT` entry.
+- `createNoArtFile(orderId)` records a `NO_ART` placeholder ("Sin Obra") with no
+  S3 object.
+- **Download**: `getFile` / `getFilesByOrder` return the file with **presigned
+  download URLs** (600 s) for the optimized key (falling back to the original)
+  and the thumbnail if present.
+- **Delete**: `deleteFile` removes the DynamoDB record, logs an `ATTACHMENT`
+  removal, and **tags every S3 key with `expiry=true`** (lifecycle-driven
+  deletion) rather than deleting immediately. `NO_ART` files skip the S3 step.
+- **Optimization sweep**: `optimizePhotoStorage()` finds originals that already
+  have an optimized variant and tags the originals `expiry=true`, in batches of
+  50 with a 1 s pause between batches. Image targets:
+  optimized `width 2160 / quality 80`, thumbnail `80×80`.
+
+`ImageVariant` = `ORIGINAL | OPTIMIZED | THUMBNAIL`; `FileType` =
+`PHOTO | VIDEO | OTHER | NO_ART`. Failures during multi-key operations are
+logged via the pino logger but don't abort the whole operation
+(`Promise.allSettled`).
+
+Persistence: composite primary key `(orderUuid, fileUuid)`.
+
+---
+
+## Reports — `ReportService`
+
+Aggregates business activity into JSON reports stored in S3 (`reportsBucket`),
+keyed by store and granularity.
+
+### Daily report — `generateAndStoreDailyReport(date)`
+Mines the **audit trail** for the day: keeps `STATUS` entries that represent an
+order **becoming `PENDING`** (from null/quote → pending) — i.e. "new orders
+booked today". For those orders it records `{ id, customerId, total }` and
+aggregates part counts (`{ id, count }`). The report is content-hashed
+(`sha256` of its JSON) for dedupe, then stored at
+`<storeId>/daily/<y>/<m>/<d>/report.json`.
+
+### Rollups
+`upadateWeeklyReport` / `upadateMonthlyReport` append a daily report into the
+week/month rollup (deduped by the daily report's hash). Stored at
+`<storeId>/weekly/<y>/<week>/report.json` and `.../monthly/<y>/<m>/...`.
+
+### Reads & dashboard
+- `getDailyReport` / `getWeeklyReport` / `getMonthlyReport` return the stored
+  JSON or an empty shell if absent.
+- `getDashboardReport(start, end)` builds a `DashboardReport` over a range:
+  daily cash & order counts, totals (orders, cash, customers, items), and
+  **top 15 orders / top 15 customers / top 25 items** (items filtered by
+  `isExcludedItem` — ids containing `sin_`, `cliente`, `espacio_blanco`,
+  `fabric` are excluded as non-product lines). It picks the most efficient
+  source for the range via `getDailyReportsBetweenDates` (same-day → daily;
+  same-week → weekly; same-month → monthly; otherwise iterate months). The end
+  date is clamped to today.
+
+Report dates use the `ReportDate = { day, month, year }` shape; date maths is
+Luxon-based.
+
+---
+
+## Public receipts — `PublicReceiptService`
+
+Powers the read-only, shareable order page. Built only by
+`ServiceFactory.createPublic(...)` → `PublicServiceFactory`, which exposes just
+`pricingService`, `calculatedItemService`, and `publicReceiptService`, all bound
+to the special `'public-repo'` store.
+
+`getPublicOrder(shortId)` reads the order from the **public** order/customer
+repositories (separate read-only views, keyed by `shortId`), rebuilds the
+`FullOrder` with its calculated item and totals, and returns `null` if any piece
+is missing.
+
+---
+
+## Store config — `ConfigService`
+
+A tiny key/value store for per-store configuration. Currently only the
+**locations list** (`LOCATIONS_CONFIG_ID = 'locations_config'`, a `string[]`):
+`getLocationsList()` / `storeLocationsList(locations)`. Persistence uses a
+composite primary key `(storeId, id)`.
+
+---
+
+## Users — `UserService`
+
+Stateless helper. `generateStaticUser(id, name, storeId)` builds a `StaticUser`
+(the lightweight user reference stored on orders/audit entries). The richer
+`AppUser` adds `priceManager: boolean` and is supplied by the host app via
+config, not created here.
+
+---
+
+## Persistence layer (DynamoDB)
+
+Repositories wrap `@balerial/dynamo`'s `BalerialDynamoRepository` and own the
+DTO ⇄ domain translation. Table + index shapes are declared once in
+**`src/repository/dynamodb/table/table.builders.dynamodb.ts`** (exported via the
+`.../core/db` entry point so the CDK app in `apps/marcos-aws` can provision
+matching tables).
+
+| Table (builder) | Primary key | Secondary indexes (GSI) |
+|---|---|---|
+| `orderTableBuilder` | `uuid` | `customer (customerUuid,timestamp)`, `shortId`, `status (status,timestamp)`, `store (storeId,timestamp)`, `publicId` — `shortId` exposed publicly |
+| `calculatedItemTableBuilder` | `orderUuid` | public primary index |
+| `customerTableBuilder` | `uuid` | `store (storeId,phone)` — public primary index |
+| `listPricingTableBuilder` | `uuid` | `type (type,id)` |
+| `orderAuditTrailTableBuilder` | `uuid` | `order (orderUuid,timestamp)`, `store (storeId,timestamp)` |
+| `orderSetTableBuilder` | `uuid` | `hash` |
+| `fileTableBuilder` | `(orderUuid, fileUuid)` | — |
+| `configTableBuilder` | `(storeId, id)` | — |
+
+The `timestamp` sort keys make the time-range queries possible
+(same-day orders, audit entries for a day, etc.). `setPublicPrimaryIndex` /
+`setPublicSecondaryIndexes` mark which access paths the public, read-only store
+is allowed to use.
+
+**DTO vs domain**: DTOs use `uuid` where domain types use `id`, store dates as
+epoch millis (`timestamp`), and carry denormalised search fields
+(`normalizedName`, `normalizedDescription`). Each service's static
+`toDto`/`fromDto` is the single conversion boundary and also where defaults for
+older records are filled in (e.g. `discountAllowed ?? true`,
+`dimensionsType` inferred from legacy `exterior*` fields).
+
+---
+
+## Errors — `src/error`
+
+Typed `Error` subclasses (each restores its prototype chain so `instanceof`
+works across the transpile boundary):
+
+| Error | Thrown when |
+|---|---|
+| `InvalidDataError` | Invalid item/customer/payment input (bad quantity, phone, negative amount). |
+| `InvalidSizeError` | Requested dimensions exceed an entry's max, or no `FIT_AREA` step matches. Carries a Spanish, user-facing message. |
+| `InvalidKeyError` | A price `id` already exists under a different uuid (uniqueness violation). |
+
+`InvalidSizeError` messages are surfaced directly to users, so they're written
+in Spanish.
+
+---
+
+## Logging — `src/logger/logger.ts`
+
+`getLogger(name, forLambda?)` returns a [pino](https://getpino.io) logger.
+Outside Lambda it pretty-prints (colorized) for local dev; inside Lambda it logs
+plain JSON (CloudWatch-friendly). `getLoggerForLambda(name)` is the Lambda
+shortcut. Currently used by `FileService` for the storage-optimization sweeps.
+
+---
+
+## Configuration recap
+
+All services take an `ICoreConfiguration` (carries explicit AWS
+`region` + `credentials`) or `ICoreConfigurationForAWSLambda` (no credentials —
+uses the execution role). `getClientConfiguration(config)` returns `{}` for
+Lambda or `{ region, credentials }` otherwise, and is what every repository and
+S3 service is initialised with. The config also carries every table/bucket name,
+the current `user`, the `storeId`, and `disableOrderAuditTrail`. Missing a
+required table/bucket name throws at construction time (fail fast).
+</content>


### PR DESCRIPTION
## Summary

This PR adds three comprehensive markdown documentation files to `packages/marcos-core/docs/` that explain the core business logic, architecture, and implementation details of the pricing engine, order lifecycle, and supporting services. These docs serve as the primary reference for understanding how the package works.

## Key changes

- **`docs/pricing.md`** (385 lines) — Complete guide to the pricing engine:
  - Vocabulary of pricing types (`MOLD`, `FABRIC`, `GLASS`, etc.) and formulas
  - `ListPrice` catalog entry structure and overloaded `price` field
  - Dimension handling (original, total, working) and which paths use which
  - All formula functions with mathematical definitions (`linearPricing`, `areaPricing`, `leftoverPricing`, `fitAreaPricing`, etc.)
  - Fabric and crossbar pricing logic
  - Mold matrix lookup and Excel bulk loader
  - Markup system for external orders
  - Dimension limits and validation
  - DynamoDB persistence via `ListPricingRepositoryDynamoDb`
  - Worked example (50×70 cm picture with mold, glass, backboard)

- **`docs/orders.md`** (254 lines) — Complete guide to the order lifecycle:
  - Domain model (`Item`, `Order`, `OrderStatus`, `ExternalOrder`)
  - From form submission to persisted, priced order
  - `CalculatedItem` and how parts are priced
  - Totals, discounts, and payment operations
  - Status transitions and state machine
  - Read paths and queries
  - Order sets (grouping by customer)
  - Audit trail recording
  - Temp customer for walk-ins

- **`docs/services.md`** (200 lines) — Guide to supporting services and infrastructure:
  - `CustomerService` (CRUD, search, phone validation)
  - `FileService` (S3 attachments, presigned URLs, optimization)
  - `ReportService` (daily/weekly/monthly reports, dashboard)
  - `PublicReceiptService` (read-only shareable orders)
  - `ConfigService` (store configuration)
  - `UserService` (static user generation)
  - DynamoDB persistence layer (table builders, GSIs, DTO translation)
  - Typed domain errors (`InvalidDataError`, `InvalidSizeError`, `InvalidKeyError`)
  - Logging via pino
  - Configuration recap

- **`README.md`** (171 lines) — Package overview and entry point:
  - High-level description of what the package does
  - Links to the three detailed docs
  - Package layout and directory structure
  - Public entry points (exports)
  - Architecture diagram
  - Configuration and `ServiceFactory` explanation
  - Conventions (money rounding, dimensions in cm, ID naming, Spanish UI text)

## Notable implementation details

- All documentation is written in Markdown with clear section numbering and cross-references
- Pricing formulas include exact mathematical notation and rounding behavior
- Tables summarize key mappings (pricing types → paths, formulas → functions, etc.)
- The worked example in `pricing.md` ties together dimensions, formulas, and the mold matrix
- Architecture diagrams use ASCII art to show service dependencies and data flow
- All three docs link to each other for easy navigation
- Spanish UI text is highlighted where it surfaces to users

https://claude.ai/code/session_01QWty9YSb738PnfmBMVJzhU